### PR TITLE
Update non-empty email only

### DIFF
--- a/tamusers/user_utils.py
+++ b/tamusers/user_utils.py
@@ -50,6 +50,9 @@ def populate_user(user, data):
     for field in user_fields:
         if field in data:
             val = data[field]
+            # Only update the email address if it's non-empty
+            if not val and field == "email":
+                continue
             if getattr(user, field) != val:
                 setattr(user, field, val)
                 changed = True


### PR DESCRIPTION
When updating the user details, do not update the user's email address if the email address from the provider is empty.

Refs STAM-5